### PR TITLE
WEB-49 : Réparation du docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "jirai_u"]
+      test: ["CMD", "pg_isready", "-U", "jirai_u", "-d", "jirai_d"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This pull request includes a minor update to the `docker-compose.yml` file to enhance the database health check configuration.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L15-R15): Updated the `healthcheck` command to include a database name (`jirai_d`) in addition to the username (`jirai_u`) for more precise readiness checks.