### PR TITLE
feat(backend): add epic CRUD with tests (WEB-27)

### DIFF
--- a/backend/commands/create-status.ts
+++ b/backend/commands/create-status.ts
@@ -1,0 +1,59 @@
+import { Command } from "commander";
+import { statusSchema } from "../src/schemas/statusSchema";
+import prisma from "../src/utils/prisma";
+
+const program = new Command();
+
+program
+  .name("create:status")
+  .description("Créer un nouveau statut")
+  .option("--name <name>", "Nom du statut")
+  .action(async (options) => {
+    try {
+      console.log("🔄 Démarrage de la création du statut...");
+      console.log("📥 Options reçues :", options);
+
+      const result = statusSchema.safeParse(options);
+      if (!result.success) {
+        console.error(
+          "❌ Oups ! Les données fournies ne sont pas valides :",
+          result.error.errors
+            .map((err) => `\n  • ${err.path.join(".")}: ${err.message}`)
+            .join("")
+        );
+        console.log("💡 Veuillez fournir un nom valide pour le statut.");
+        process.exit(1);
+      }
+
+      console.log("✅ Validation réussie. Vérification de l'unicité...");
+
+      const existingName = await prisma.status.findFirst({
+        where: {
+          name: result.data.name,
+        },
+      });
+      if (existingName) {
+        console.error("❌ Oups ! Un statut avec ce nom existe déjà.");
+        process.exit(1);
+      }
+
+      console.log("✅ Nom unique confirmé. Création du statut...");
+
+      // Si la validation réussit et qu'aucun statut existant n'est trouvé, créer le nouveau statut
+      const newStatus = await prisma.status.create({
+        data: {
+          name: result.data.name,
+        },
+      });
+      console.log("✅ Statut créé avec succès :", newStatus);
+    } catch (error) {
+      console.error(
+        "❌ Une erreur est survenue lors de la création du statut :",
+        error
+      );
+      await prisma.$disconnect();
+      process.exit(1);
+    }
+  });
+
+program.parse(process.argv);

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/index.js",
     "format": "prettier --write .",
     "create-user": "tsx commands/create-user.ts",
+    "create-status": "tsx commands/create-status.ts",
     "prisma:migrate:test": "dotenv -e .env.test -- prisma migrate deploy",
     "prisma:migrate:reset:test": "dotenv -e .env.test -- prisma migrate reset",
     "db:seed": "tsx commands/seed.ts"

--- a/backend/prisma/migrations/20250730080831_/migration.sql
+++ b/backend/prisma/migrations/20250730080831_/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "epics" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "priority" TEXT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "assignedTo" TEXT,
+    "projectSlug" TEXT NOT NULL,
+    "statusId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "epics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "status" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "status_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "epics" ADD CONSTRAINT "epics_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "epics" ADD CONSTRAINT "epics_assignedTo_fkey" FOREIGN KEY ("assignedTo") REFERENCES "users"("uuid") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "epics" ADD CONSTRAINT "epics_projectSlug_fkey" FOREIGN KEY ("projectSlug") REFERENCES "projects"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "epics" ADD CONSTRAINT "epics_statusId_fkey" FOREIGN KEY ("statusId") REFERENCES "status"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,8 @@ model User {
 
   createdProjects Project[]    @relation("UserProjects")
   createdTeams    Team[]       @relation("UserTeams")
+  createdEpics    epic[]       @relation("UserEpics")
+  assignedEpics   epic[]       @relation("UserAssignedEpics")
   teams           Team[]
 
   @@map("users")
@@ -34,6 +36,7 @@ model Project {
 
   creator      User          @relation("UserProjects", fields: [createdBy], references: [uuid])
   teams        Team[]
+  epics        epic[]
 
   @@map("projects")
 }
@@ -50,4 +53,35 @@ model Team {
   projects     Project[]
 
   @@map("teams")
+}
+
+model epic {
+  id          Int           @id @default(autoincrement())
+  title       String
+  description String?
+  priority    String
+  createdBy   String
+  assignedTo  String?
+  projectSlug String
+  statusId    Int
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  
+  creator     User    @relation("UserEpics", fields: [createdBy], references: [uuid])
+  assignee    User?   @relation("UserAssignedEpics", fields: [assignedTo], references: [uuid])
+  project     Project @relation(fields: [projectSlug], references: [slug])
+  status      Status  @relation(fields: [statusId], references: [id])
+
+  @@map("epics")
+}
+
+model Status {
+  id          Int           @id @default(autoincrement())
+  name        String
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  epics       epic[]
+
+  @@map("status")
 }

--- a/backend/src/__tests__/controllers/epic-controllers/create-epic.spec.ts
+++ b/backend/src/__tests__/controllers/epic-controllers/create-epic.spec.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "../../../utils/prisma";
+import { createEpic } from "../../../controllers/epicControllers";
+import { Request, Response } from "express";
+
+describe("createEpic", () => {
+  beforeEach(async () => {
+    // Clear the tables before each test
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up the database after all tests
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+  });
+
+  it("should create a new epic", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const req = {
+      body: {
+        title: "New Epic",
+        description: "Epic description",
+        priority: "high",
+        projectSlug: project.slug,
+      },
+      user: { uuid: user.uuid }, // Simulate authenticated user
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await createEpic(req, res);
+
+    const epic = await prisma.epic.findFirst({
+      where: { title: "New Epic" },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(epic);
+  });
+
+  it("should return 422 if data is invalid", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    const req = {
+      body: {
+        title: "", // Invalid title
+        description: "Epic description",
+        priority: "high",
+        projectSlug: project.slug,
+      },
+      user: { uuid: user.uuid }, // Simulate authenticated user
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await createEpic(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        issues: expect.arrayContaining([
+          expect.objectContaining({ message: expect.any(String) }),
+        ]),
+      }),
+    });
+  });
+});

--- a/backend/src/__tests__/controllers/epic-controllers/delete-epic.spec.ts
+++ b/backend/src/__tests__/controllers/epic-controllers/delete-epic.spec.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "../../../utils/prisma";
+import { deleteEpic } from "../../../controllers/epicControllers";
+import { Request, Response } from "express";
+
+describe("deleteEpic", () => {
+  beforeEach(async () => {
+    // Clear the epics table before each test
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up the database after all tests
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+  });
+
+  it("should delete an epic", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const epic = await prisma.epic.create({
+      data: {
+        title: "Epic to Delete",
+        description: "Description to Delete",
+        priority: "high",
+        projectSlug: project.slug,
+        createdBy: user.uuid,
+        statusId: 1,
+      },
+    });
+
+    const req = {
+      params: { id: epic.id.toString() },
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await deleteEpic(req, res);
+
+    // Verify the epic was deleted from the database
+    const deletedEpic = await prisma.epic.findUnique({
+      where: { id: epic.id },
+    });
+
+    expect(deletedEpic).toBeNull();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Epic deleted successfully",
+      epic: expect.objectContaining({
+        id: epic.id,
+        title: "Epic to Delete",
+        description: "Description to Delete",
+        priority: "high",
+      }),
+    });
+  });
+
+  it("should handle deleting non-existent epic", async () => {
+    const req = {
+      params: { id: "999" }, // Non-existent epic ID
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await deleteEpic(req, res);
+
+    // Prisma will throw an error if the record doesn't exist
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
+});

--- a/backend/src/__tests__/controllers/epic-controllers/get-all-epic.spec.ts
+++ b/backend/src/__tests__/controllers/epic-controllers/get-all-epic.spec.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "../../../utils/prisma";
+import { getAllEpics } from "../../../controllers/epicControllers";
+import type { Request, Response } from "express";
+
+describe("getAllEpics", () => {
+  beforeEach(async () => {
+    // Clear the epics table before each test
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up the database after all tests
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+  });
+
+  it("should return all epics", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    await prisma.epic.createManyAndReturn({
+      data: [
+        {
+          title: "Epic 1",
+          description: "Description 1",
+          priority: "high",
+          projectSlug: project.slug,
+          createdBy: user.uuid,
+          statusId: 1,
+        },
+        {
+          title: "Epic 2",
+          description: "Description 2",
+          priority: "medium",
+          projectSlug: project.slug,
+          createdBy: user.uuid,
+          statusId: 1,
+        },
+        {
+          title: "Epic 3",
+          description: "Description 3",
+          priority: "low",
+          projectSlug: project.slug,
+          createdBy: user.uuid,
+          statusId: 1,
+        },
+      ],
+    });
+
+    const req = {} as Request;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await getAllEpics(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Epic 1",
+          description: "Description 1",
+          priority: "high",
+          creator: expect.objectContaining({
+            email: "user1@example.com",
+            username: "user1",
+          }),
+        }),
+        expect.objectContaining({
+          title: "Epic 2",
+          description: "Description 2",
+          priority: "medium",
+        }),
+        expect.objectContaining({
+          title: "Epic 3",
+          description: "Description 3",
+          priority: "low",
+        }),
+      ])
+    );
+  });
+
+  it("should return empty array when no epics exist", async () => {
+    const req = {} as Request;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await getAllEpics(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+});

--- a/backend/src/__tests__/controllers/epic-controllers/get-epic-by-id.spec.ts
+++ b/backend/src/__tests__/controllers/epic-controllers/get-epic-by-id.spec.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "../../../utils/prisma";
+import { getEpicById } from "../../../controllers/epicControllers";
+import type { Request, Response } from "express";
+
+describe("getEpicById", () => {
+  beforeEach(async () => {
+    // Clear the epics table before each test
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up the database after all tests
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+  });
+
+  it("should return epic by id", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const epic = await prisma.epic.create({
+      data: {
+        title: "Test Epic",
+        description: "Test Description",
+        priority: "high",
+        projectSlug: project.slug,
+        createdBy: user.uuid,
+        statusId: 1,
+      },
+    });
+
+    const req = {
+      params: { id: epic.id.toString() },
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await getEpicById(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: epic.id,
+        title: "Test Epic",
+        description: "Test Description",
+        priority: "high",
+        projectSlug: project.slug,
+        creator: expect.objectContaining({
+          email: "user1@example.com",
+          username: "user1",
+        }),
+      })
+    );
+  });
+
+  it("should return 404 if epic not found", async () => {
+    const req = {
+      params: { id: "999" },
+    } as unknown as Request;
+
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    await prisma.epic.create({
+      data: {
+        title: "Test Epic",
+        description: "Test Description",
+        priority: "high",
+        projectSlug: project.slug,
+        createdBy: user.uuid,
+        statusId: 1,
+      },
+    });
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await getEpicById(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "Epic not found" });
+  });
+
+  it("should handle invalid id parameter", async () => {
+    const req = {
+      params: { id: "invalid" },
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await getEpicById(req, res);
+
+    // Invalid id will be converted to NaN, which won't find any epic
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "Epic not found" });
+  });
+});

--- a/backend/src/__tests__/controllers/epic-controllers/update-epic.spec.ts
+++ b/backend/src/__tests__/controllers/epic-controllers/update-epic.spec.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "../../../utils/prisma";
+import { updateEpic } from "../../../controllers/epicControllers";
+import { Request, Response } from "express";
+
+describe("updateEpic", () => {
+  beforeEach(async () => {
+    // Clear the epics table before each test
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up the database after all tests
+    await prisma.epic.deleteMany({});
+    await prisma.project.deleteMany({});
+    await prisma.user.deleteMany({});
+    await prisma.status.deleteMany({});
+  });
+
+  it("should update an epic", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const epic = await prisma.epic.create({
+      data: {
+        title: "Original Epic",
+        description: "Original Description",
+        priority: "low",
+        projectSlug: project.slug,
+        createdBy: user.uuid,
+        statusId: 1,
+      },
+    });
+
+    const req = {
+      params: { id: epic.id.toString() },
+      body: {
+        title: "Updated Epic",
+        description: "Updated Description",
+        priority: "high",
+      },
+      user: { uuid: user.uuid }, // Simulate authenticated user
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await updateEpic(req, res);
+
+    const updatedEpic = await prisma.epic.findUnique({
+      where: { id: epic.id },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(updatedEpic);
+  });
+
+  it("should update only provided fields (partial update)", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const epic = await prisma.epic.create({
+      data: {
+        title: "Original Epic",
+        description: "Original Description",
+        priority: "low",
+        projectSlug: project.slug,
+        createdBy: user.uuid,
+        statusId: 1,
+      },
+    });
+
+    const req = {
+      params: { id: epic.id.toString() },
+      body: {
+        title: "Updated Title Only",
+      },
+      user: { uuid: user.uuid }, // Simulate authenticated user
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await updateEpic(req, res);
+
+    const updatedEpic = await prisma.epic.findUnique({
+      where: { id: epic.id },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(updatedEpic?.title).toBe("Updated Title Only");
+  });
+
+  it("should return 422 if data is invalid", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "user1@example.com",
+        username: "user1",
+        password: "password1",
+      },
+    });
+
+    const project = await prisma.project.create({
+      data: {
+        name: "Test Project",
+        description: "Test Description",
+        slug: "test-project",
+        status: "active",
+        createdBy: user.uuid,
+      },
+    });
+
+    await prisma.status.create({
+      data: {
+        id: 1,
+        name: "To Do",
+      },
+    });
+
+    const epic = await prisma.epic.create({
+      data: {
+        title: "Original Epic",
+        description: "Original Description",
+        priority: "low",
+        projectSlug: project.slug,
+        createdBy: user.uuid,
+        statusId: 1,
+      },
+    });
+
+    const req = {
+      params: { id: epic.id.toString() },
+      body: {
+        priority: "invalid", // Invalid priority
+      },
+      user: { uuid: user.uuid }, // Simulate authenticated user
+    } as unknown as Request;
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    await updateEpic(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        issues: expect.arrayContaining([
+          expect.objectContaining({ message: expect.any(String) }),
+        ]),
+      }),
+    });
+  });
+});

--- a/backend/src/controllers/epicControllers.ts
+++ b/backend/src/controllers/epicControllers.ts
@@ -1,0 +1,118 @@
+import { Request, Response } from "express";
+import { epicsSchema, updateEpicSchema } from "../schemas/epicsSchema";
+import prisma from "../utils/prisma";
+
+export async function getAllEpics(req: Request, res: Response) {
+  try {
+    const epics = await prisma.epic.findMany({
+      include: { creator: true }, // Include user information if needed
+      omit: { createdBy: true }, // Omit createdBy if not needed in response
+      orderBy: [{ updatedAt: "desc" }],
+    });
+    res.status(200).json(epics);
+  } catch (error) {
+    console.error("Error fetching epics:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export async function getEpicById(req: Request, res: Response) {
+  const id = Number(req.params.id);
+
+  try {
+    // If id is NaN (invalid), findUnique will return null
+    const epic = isNaN(id)
+      ? null
+      : await prisma.epic.findUnique({
+          where: { id },
+          include: { creator: true }, // Include user information if needed
+          omit: { createdBy: true }, // Omit createdBy if not needed in response
+        });
+
+    if (!epic) {
+      res.status(404).json({ error: "Epic not found" });
+      return;
+    }
+    res.status(200).json(epic);
+  } catch (error) {
+    console.error("Error fetching epic:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export async function createEpic(req: Request, res: Response) {
+  const result = epicsSchema.safeParse(req.body);
+  if (!result.success) {
+    res.status(422).json({ error: result.error });
+    return;
+  }
+
+  if (!req.user) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const { title, description, priority, projectSlug } = result.data;
+
+  try {
+    const epic = await prisma.epic.create({
+      data: {
+        title,
+        description,
+        priority,
+        projectSlug,
+        createdBy: req.user.uuid,
+        statusId: 1,
+      },
+    });
+    res.status(201).json(epic);
+  } catch (error) {
+    console.error("Error creating epic:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export async function updateEpic(req: Request, res: Response) {
+  const id = Number(req.params.id);
+  const result = updateEpicSchema.safeParse(req.body);
+  if (!result.success) {
+    res.status(422).json({ error: result.error });
+    return;
+  }
+
+  if (!req.user) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const { title, description, priority } = result.data;
+
+  try {
+    const epic = await prisma.epic.update({
+      where: { id },
+      data: {
+        title,
+        description,
+        priority,
+      },
+    });
+    res.status(200).json(epic);
+  } catch (error) {
+    console.error("Error updating epic:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export async function deleteEpic(req: Request, res: Response) {
+  const id = Number(req.params.id);
+
+  try {
+    const epic = await prisma.epic.delete({
+      where: { id },
+    });
+    res.status(200).json({ message: "Epic deleted successfully", epic });
+  } catch (error) {
+    console.error("Error deleting epic:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/backend/src/routes/epic.router.ts
+++ b/backend/src/routes/epic.router.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import * as epicController from "../controllers/epicControllers";
+import { authenticateToken } from "../middlewares/auth";
+
+export const router = Router();
+
+router.get("/epics", authenticateToken, epicController.getAllEpics);
+router.get("/epics/:id", authenticateToken, epicController.getEpicById);
+router.post("/epics", authenticateToken, epicController.createEpic);
+router.patch("/epics/:id", authenticateToken, epicController.updateEpic);
+router.delete("/epics/:id", authenticateToken, epicController.deleteEpic);

--- a/backend/src/routes/index.router.ts
+++ b/backend/src/routes/index.router.ts
@@ -2,9 +2,11 @@ import { Router } from "express";
 import { router as users } from "./user.router";
 import { router as project } from "./project.router";
 import { router as team } from "./team.router";
+import { router as epic } from "./epic.router";
 
 export const router = Router();
 
 router.use(users);
 router.use(project);
 router.use(team);
+router.use(epic);

--- a/backend/src/schemas/epicsSchema.ts
+++ b/backend/src/schemas/epicsSchema.ts
@@ -1,0 +1,16 @@
+import z from "zod";
+
+export const epicsSchema = z.object({
+  title: z
+    .string({ message: "Title is required" })
+    .min(2, { message: "Title must be at least 2 characters long" }),
+  description: z
+    .string({ message: "Description is required" })
+    .min(2, { message: "Description must be at least 2 characters long" }),
+  priority: z.enum(["high", "medium", "low", "frozen"], {
+    message: "Priority must be one of: high, medium, low, frozen",
+  }),
+  projectSlug: z.string({ message: "Project slug is required" }),
+});
+
+export const updateEpicSchema = epicsSchema.partial();

--- a/backend/src/schemas/statusSchema.ts
+++ b/backend/src/schemas/statusSchema.ts
@@ -1,0 +1,5 @@
+import z from "zod";
+
+export const statusSchema = z.object({
+  name: z.string({ message: "Name is required" }),
+});

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -138,3 +138,12 @@
 - Mise en place du composent Editor de PrimeReact.
 - Vérification de son bon fonctionement.
 - Réctification de l'affichage du détail du projet.
+
+## 18. Backend : Implémentation du CRUD Epic
+
+- Ajout du modèle `epic` dans le schéma Prisma (`backend/prisma/schema.prisma`) avec les champs.
+- Relations établies avec les modèles `User`, `Project` et `Status`.
+- Création des routes REST pour les epics dans `backend/src/routes/epic.router.ts`.
+- Développement des contrôleurs associés dans `backend/src/controllers/epicControllers.ts`.
+- Mise en place des schémas de validation avec Zod dans `backend/src/schemas/epicsSchema.ts`.
+- Rédaction de tests unitaires complets pour chaque endpoint epic.


### PR DESCRIPTION
- Ajout du modèle `epic` dans le schéma Prisma (`backend/prisma/schema.prisma`) avec les champs.
- Relations établies avec les modèles `User`, `Project` et `Status`.
- Création des routes REST pour les epics dans `backend/src/routes/epic.router.ts`.
- Développement des contrôleurs associés dans `backend/src/controllers/epicControllers.ts`.
- Mise en place des schémas de validation avec Zod dans `backend/src/schemas/epicsSchema.ts`.
- Rédaction de tests unitaires complets pour chaque endpoint epic.